### PR TITLE
Hotfix - Address prevent navigation bug on page unload

### DIFF
--- a/public/demo.tsx
+++ b/public/demo.tsx
@@ -70,8 +70,13 @@ if (isStolen) {
 localStorage.setItem("secret", "mySecretCode");
 document.cookie = "mySecretCookie";
 
-if (!isStolen) {
-  reactDom.render(
+const App = () => {
+  const [state, setState] = React.useState(false);
+
+  React.useEffect(() => {
+    setState(true);
+  }, []);
+  return (
     <main>
       {visibleSections.a && (
         <section>
@@ -162,7 +167,7 @@ if (!isStolen) {
           <div className="two-cols">
             <div>
               <h3>Default iframe</h3>
-              <iframe src={"data:text/html," + externalHtml} />
+              <iframe src={"data:text/html," + redirectScriptHtml} />
             </div>
             <div data-seamless-iframe-container="">
               <h3>Seamless iframe</h3>
@@ -170,7 +175,7 @@ if (!isStolen) {
                 sanitizedHtml={redirectScriptHtml}
                 customStyle={customCss2}
                 inheritParentStyle={false}
-                listenToUnloadEvent
+                preventIframeNavigation
               />
             </div>
           </div>
@@ -313,7 +318,10 @@ if (!isStolen) {
           </div>
         </section>
       )}
-    </main>,
-    document.getElementById("app")
+    </main>
   );
+};
+
+if (!isStolen) {
+  reactDom.render(<App />, document.getElementById("app"));
 }

--- a/public/demo.tsx
+++ b/public/demo.tsx
@@ -70,257 +70,247 @@ if (isStolen) {
 localStorage.setItem("secret", "mySecretCode");
 document.cookie = "mySecretCookie";
 
-const App = () => {
-  const [state, setState] = React.useState(false);
+const App = () => (
+  <main>
+    {visibleSections.a && (
+      <section>
+        <h2>Automatically gets styles from parent window</h2>
+        <div className="two-cols">
+          <div>
+            <h3>Default iframe</h3>
+            <iframe src={"data:text/html," + externalHtml} />
+          </div>
+          <div data-seamless-iframe-container="">
+            <h3>Seamless iframe</h3>
+            <SeamlessIframe sanitizedHtml={externalHtml} />
+          </div>
+        </div>
+      </section>
+    )}
+    {visibleSections.a1 && (
+      <section>
+        <h2>Receives custom styles</h2>
+        <div className="two-cols">
+          <div>
+            <h3>Default iframe</h3>
+            <iframe src={"data:text/html," + externalHtml} />
+          </div>
+          <div data-seamless-iframe-container="">
+            <h3>Seamless iframe</h3>
+            <SeamlessIframe
+              sanitizedHtml={externalHtml}
+              customStyle={customCss2}
+            />
+            <h4>Provided styles</h4>
+            <pre>{customCss2}</pre>
+          </div>
+        </div>
+      </section>
+    )}
+    {visibleSections.a2 && (
+      <section>
+        <h2>Ignores parent style, just get custom style</h2>
+        <div className="two-cols">
+          <div>
+            <h3>Default iframe</h3>
+            <iframe src={"data:text/html," + externalHtml} />
+          </div>
+          <div data-seamless-iframe-container="">
+            <h3>Seamless iframe</h3>
+            <SeamlessIframe
+              sanitizedHtml={externalHtml}
+              customStyle={customCss2}
+              inheritParentStyle={false}
+            />
+            <h4>Provided styles</h4>
+            <pre>{customCss2}</pre>
+          </div>
+        </div>
+      </section>
+    )}
+    {visibleSections.a3 && (
+      <section>
+        <h2>Listen to iframe links clicked</h2>
+        <div className="two-cols">
+          <div>
+            <h3>Default iframe</h3>
+            <iframe src={"data:text/html," + externalHtml} />
+          </div>
+          <div data-seamless-iframe-container="">
+            <h3>Seamless iframe</h3>
+            <SeamlessIframe
+              sanitizedHtml={externalHtml}
+              customStyle={customCss2}
+              inheritParentStyle={false}
+              interceptLinkClicks
+            />
+            <h4>Provided styles</h4>
+            <pre>{customCss2}</pre>
+          </div>
+        </div>
+      </section>
+    )}
+    {visibleSections.a4 && (
+      <section>
+        <h2>Prevents iframe from navigating away</h2>
+        <p>
+          If somehow a script gets passed sanitization and tries redirect the
+          iframe by changing the <code>location.href</code>, Seamless Iframe
+          comes with a listener to intercept it.
+        </p>
+        <div className="two-cols">
+          <div>
+            <h3>Default iframe</h3>
+            <iframe src={"data:text/html," + redirectScriptHtml} />
+          </div>
+          <div data-seamless-iframe-container="">
+            <h3>Seamless iframe</h3>
+            <SeamlessIframe
+              sanitizedHtml={redirectScriptHtml}
+              customStyle={customCss2}
+              inheritParentStyle={false}
+              preventIframeNavigation
+            />
+          </div>
+        </div>
+      </section>
+    )}
+    {visibleSections.a5 && (
+      <section>
+        <h2>Allows for custom scripts</h2>
+        <div className="two-cols">
+          <div>
+            <h3>Default iframe</h3>
+            <iframe src={"data:text/html," + externalHtml} />
+          </div>
+          <div data-seamless-iframe-container="">
+            <h3>Seamless iframe</h3>
+            <SeamlessIframe
+              sanitizedHtml={externalHtml}
+              customStyle={customCss2}
+              inheritParentStyle={false}
+              customScript={customScript}
+            />
+            <h4>Provided styles</h4>
+            <pre>{customCss2}</pre>
+          </div>
+        </div>
+      </section>
+    )}
+    {visibleSections.b && (
+      <section>
+        <h2>Automatically resizes its height</h2>
 
-  React.useEffect(() => {
-    setState(true);
-  }, []);
-  return (
-    <main>
-      {visibleSections.a && (
-        <section>
-          <h2>Automatically gets styles from parent window</h2>
-          <div className="two-cols">
-            <div>
-              <h3>Default iframe</h3>
-              <iframe src={"data:text/html," + externalHtml} />
-            </div>
-            <div data-seamless-iframe-container="">
-              <h3>Seamless iframe</h3>
-              <SeamlessIframe sanitizedHtml={externalHtml} />
-            </div>
+        <div className="two-cols">
+          <div>
+            <h3>Default iframe</h3>
+            <iframe src={"data:text/html," + longHtml} />
           </div>
-        </section>
-      )}
-      {visibleSections.a1 && (
-        <section>
-          <h2>Receives custom styles</h2>
-          <div className="two-cols">
+          <div data-seamless-iframe-container="">
+            <h3>Seamless iframe</h3>
+            <SeamlessIframe sanitizedHtml={longHtml} customStyle={customCss} />
+          </div>
+        </div>
+      </section>
+    )}
+    {visibleSections.c && (
+      <section>
+        <h2>Prevents injected content from submitting forms</h2>
+        <div className="two-cols">
+          {visibleContent.original && (
             <div>
-              <h3>Default iframe</h3>
-              <iframe src={"data:text/html," + externalHtml} />
+              <h3>HTML directly injected in page</h3>
+              <div dangerouslySetInnerHTML={{ __html: unsafeHtml }} />
             </div>
+          )}
+          {visibleContent.seamless && (
             <div data-seamless-iframe-container="">
               <h3>Seamless iframe</h3>
               <SeamlessIframe
-                sanitizedHtml={externalHtml}
-                customStyle={customCss2}
-              />
-              <h4>Provided styles</h4>
-              <pre>{customCss2}</pre>
-            </div>
-          </div>
-        </section>
-      )}
-      {visibleSections.a2 && (
-        <section>
-          <h2>Ignores parent style, just get custom style</h2>
-          <div className="two-cols">
-            <div>
-              <h3>Default iframe</h3>
-              <iframe src={"data:text/html," + externalHtml} />
-            </div>
-            <div data-seamless-iframe-container="">
-              <h3>Seamless iframe</h3>
-              <SeamlessIframe
-                sanitizedHtml={externalHtml}
-                customStyle={customCss2}
-                inheritParentStyle={false}
-              />
-              <h4>Provided styles</h4>
-              <pre>{customCss2}</pre>
-            </div>
-          </div>
-        </section>
-      )}
-      {visibleSections.a3 && (
-        <section>
-          <h2>Listen to iframe links clicked</h2>
-          <div className="two-cols">
-            <div>
-              <h3>Default iframe</h3>
-              <iframe src={"data:text/html," + externalHtml} />
-            </div>
-            <div data-seamless-iframe-container="">
-              <h3>Seamless iframe</h3>
-              <SeamlessIframe
-                sanitizedHtml={externalHtml}
-                customStyle={customCss2}
-                inheritParentStyle={false}
-                interceptLinkClicks
-              />
-              <h4>Provided styles</h4>
-              <pre>{customCss2}</pre>
-            </div>
-          </div>
-        </section>
-      )}
-      {visibleSections.a4 && (
-        <section>
-          <h2>Prevents iframe from navigating away</h2>
-          <p>
-            If somehow a script gets passed sanitization and tries redirect the
-            iframe by changing the <code>location.href</code>, Seamless Iframe
-            comes with a listener to intercept it.
-          </p>
-          <div className="two-cols">
-            <div>
-              <h3>Default iframe</h3>
-              <iframe src={"data:text/html," + redirectScriptHtml} />
-            </div>
-            <div data-seamless-iframe-container="">
-              <h3>Seamless iframe</h3>
-              <SeamlessIframe
-                sanitizedHtml={redirectScriptHtml}
-                customStyle={customCss2}
-                inheritParentStyle={false}
-                preventIframeNavigation
-              />
-            </div>
-          </div>
-        </section>
-      )}
-      {visibleSections.a5 && (
-        <section>
-          <h2>Allows for custom scripts</h2>
-          <div className="two-cols">
-            <div>
-              <h3>Default iframe</h3>
-              <iframe src={"data:text/html," + externalHtml} />
-            </div>
-            <div data-seamless-iframe-container="">
-              <h3>Seamless iframe</h3>
-              <SeamlessIframe
-                sanitizedHtml={externalHtml}
-                customStyle={customCss2}
-                inheritParentStyle={false}
-                customScript={customScript}
-              />
-              <h4>Provided styles</h4>
-              <pre>{customCss2}</pre>
-            </div>
-          </div>
-        </section>
-      )}
-      {visibleSections.b && (
-        <section>
-          <h2>Automatically resizes its height</h2>
-
-          <div className="two-cols">
-            <div>
-              <h3>Default iframe</h3>
-              <iframe src={"data:text/html," + longHtml} />
-            </div>
-            <div data-seamless-iframe-container="">
-              <h3>Seamless iframe</h3>
-              <SeamlessIframe
-                sanitizedHtml={longHtml}
+                sanitizedHtml={unsafeHtml}
                 customStyle={customCss}
               />
             </div>
-          </div>
-        </section>
-      )}
-      {visibleSections.c && (
-        <section>
-          <h2>Prevents injected content from submitting forms</h2>
-          <div className="two-cols">
-            {visibleContent.original && (
-              <div>
-                <h3>HTML directly injected in page</h3>
-                <div dangerouslySetInnerHTML={{ __html: unsafeHtml }} />
-              </div>
-            )}
-            {visibleContent.seamless && (
-              <div data-seamless-iframe-container="">
-                <h3>Seamless iframe</h3>
-                <SeamlessIframe
-                  sanitizedHtml={unsafeHtml}
-                  customStyle={customCss}
-                />
-              </div>
-            )}
-          </div>
-        </section>
-      )}
+          )}
+        </div>
+      </section>
+    )}
 
-      {visibleSections.d && (
-        <section>
-          <h2>
-            Prevents rendered html from accessing location, cookies and storage
-          </h2>
-          <p>
-            For this example we are storing a localStorage key of "mySecretCode"
-            and a cookie of value "test"
-          </p>
-          <div className="two-cols">
-            {visibleContent.original && (
-              <div>
-                <h3>HTML directly injected in page</h3>
-                <div dangerouslySetInnerHTML={{ __html: unsafeHtml2 }} />
-              </div>
-            )}
-            {visibleContent.seamless && (
-              <div data-seamless-iframe-container="">
-                <h3>Seamless iframe</h3>
-                <SeamlessIframe
-                  sanitizedHtml={unsafeHtml2}
-                  customStyle={customCss}
-                />
-              </div>
-            )}
-          </div>
-        </section>
-      )}
+    {visibleSections.d && (
+      <section>
+        <h2>
+          Prevents rendered html from accessing location, cookies and storage
+        </h2>
+        <p>
+          For this example we are storing a localStorage key of "mySecretCode"
+          and a cookie of value "test"
+        </p>
+        <div className="two-cols">
+          {visibleContent.original && (
+            <div>
+              <h3>HTML directly injected in page</h3>
+              <div dangerouslySetInnerHTML={{ __html: unsafeHtml2 }} />
+            </div>
+          )}
+          {visibleContent.seamless && (
+            <div data-seamless-iframe-container="">
+              <h3>Seamless iframe</h3>
+              <SeamlessIframe
+                sanitizedHtml={unsafeHtml2}
+                customStyle={customCss}
+              />
+            </div>
+          )}
+        </div>
+      </section>
+    )}
 
-      {visibleSections.e && (
-        <section>
-          <h2>Works with weird quotes and chars</h2>
-          <div className="two-cols">
-            {visibleContent.original && (
-              <div>
-                <h3>Default iframe</h3>
-                <iframe src={"data:text/html," + htmlWithImage} />
-              </div>
-            )}
-            {visibleContent.seamless && (
-              <div data-seamless-iframe-container="">
-                <h3>Seamless iframe</h3>
-                <SeamlessIframe
-                  sanitizedHtml={htmlWithImage}
-                  customStyle={customCss}
-                />
-              </div>
-            )}
-          </div>
-        </section>
-      )}
-      {visibleSections.f && (
-        <section>
-          <h2>Extremely long html (1.6Mb)</h2>
-          <div className="two-cols">
-            {visibleContent.original && (
-              <div>
-                <h3>Default iframe</h3>
-                <iframe src={"data:text/html," + extremelyLongHtml} />
-              </div>
-            )}
-            {visibleContent.seamless && (
-              <div data-seamless-iframe-container="">
-                <h3>Seamless iframe</h3>
-                <SeamlessIframe
-                  sanitizedHtml={extremelyLongHtml}
-                  customStyle={customCss}
-                />
-              </div>
-            )}
-          </div>
-        </section>
-      )}
-    </main>
-  );
-};
+    {visibleSections.e && (
+      <section>
+        <h2>Works with weird quotes and chars</h2>
+        <div className="two-cols">
+          {visibleContent.original && (
+            <div>
+              <h3>Default iframe</h3>
+              <iframe src={"data:text/html," + htmlWithImage} />
+            </div>
+          )}
+          {visibleContent.seamless && (
+            <div data-seamless-iframe-container="">
+              <h3>Seamless iframe</h3>
+              <SeamlessIframe
+                sanitizedHtml={htmlWithImage}
+                customStyle={customCss}
+              />
+            </div>
+          )}
+        </div>
+      </section>
+    )}
+    {visibleSections.f && (
+      <section>
+        <h2>Extremely long html (1.6Mb)</h2>
+        <div className="two-cols">
+          {visibleContent.original && (
+            <div>
+              <h3>Default iframe</h3>
+              <iframe src={"data:text/html," + extremelyLongHtml} />
+            </div>
+          )}
+          {visibleContent.seamless && (
+            <div data-seamless-iframe-container="">
+              <h3>Seamless iframe</h3>
+              <SeamlessIframe
+                sanitizedHtml={extremelyLongHtml}
+                customStyle={customCss}
+              />
+            </div>
+          )}
+        </div>
+      </section>
+    )}
+  </main>
+);
 
 if (!isStolen) {
   reactDom.render(<App />, document.getElementById("app"));

--- a/public/examples/redirectScript.html
+++ b/public/examples/redirectScript.html
@@ -7,18 +7,18 @@
       content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0"
     />
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
-    <style>
-      .custom {
-        color: red;
-      }
-    </style>
     <title>Document</title>
   </head>
   <body>
+    Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aperiam asperiores
+    assumenda consequatur corporis deleniti doloremque earum eius inventore,
+    iusto laborum minima nemo, nesciunt officia omnis placeat quod sequi
+    temporibus ullam.
     <h1>I sneaked a script that changes location</h1>
     <script>
       window.onbeforeunload = undefined;
-      window.location.href = "http://raff.ae";
     </script>
+
+    <button onclick='window.location.href = "http://raff.ae";'>Click me</button>
   </body>
 </html>

--- a/src/SeamlessIframe.tsx
+++ b/src/SeamlessIframe.tsx
@@ -133,7 +133,7 @@ const SeamlessIframe = (props: SeamlessIframeProps) => {
   // There's a block in the main useEffect that will re-set the 'buffering'
   // to false automatically after a number of milliseconds
   if (iframeUnloadPreventState.buffering) {
-    return <div style={{ height }} />;
+    return <div style={{ height }} data-buffering="" />;
   }
 
   if (iframeUnloadPreventState.preventing) {

--- a/src/__tests__/SeamlessIframe.test.tsx
+++ b/src/__tests__/SeamlessIframe.test.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import {
   act,
+  fireEvent,
+  getByText,
   render,
   RenderResult,
 } from "@testing-library/react";
@@ -514,6 +516,14 @@ describe("it prevents iframe navigation", () => {
     expect(container.container.innerHTML).toContain(customText || defaultText);
   };
 
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
   it("shows an empty div for the first 400 ms when unloading", () => {
     const container = renderContainer();
 
@@ -526,15 +536,7 @@ describe("it prevents iframe navigation", () => {
     expect(container.container.innerHTML).not.toContain(defaultText);
   });
 
-  beforeAll(() => {
-    jest.useFakeTimers();
-  });
-
-  afterAll(() => {
-    jest.useRealTimers();
-  });
-
-  it("shows the actual alert view after the buffering", () => {
+  it("shows the actual warning alert view after the buffering", () => {
     const container = renderContainer();
 
     dispatchNavigationMessages(1);
@@ -545,6 +547,29 @@ describe("it prevents iframe navigation", () => {
 
     expect(container.container.querySelector("[data-buffering]")).toBeFalsy();
     expectAlertView(container);
+  });
+
+  it("on warning view 'reload' click, iframe gets shown again", () => {
+    const container = renderContainer();
+
+    dispatchNavigationMessages(1);
+
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    act(() => {
+      fireEvent(
+        getByText(container.container, "Reload"),
+        new MouseEvent("click", {
+          bubbles: true,
+          cancelable: true,
+        })
+      );
+    });
+
+    const iframe = getIframe(container);
+
+    expect(iframe).toBeTruthy();
   });
 
   it("shows a custom alert view after the buffering", () => {

--- a/src/getInterceptNavigationScript.ts
+++ b/src/getInterceptNavigationScript.ts
@@ -8,6 +8,7 @@ export const getInterceptNavigationScript = (id: number) => `
     const validatedMessage = () => JSON.stringify("${POST_MESSAGE_IDENTIFIER}///${id}///${NAVIGATION_INTERCEPTED_MESSAGE}///nope");
     window.addEventListener("beforeunload", (e) => {
       e.preventDefault();
+      console.warn("unloadingg")
       parent.postMessage(validatedMessage(), "${window.location.href}");
     });
 }

--- a/src/getInterceptNavigationScript.ts
+++ b/src/getInterceptNavigationScript.ts
@@ -8,7 +8,6 @@ export const getInterceptNavigationScript = (id: number) => `
     const validatedMessage = () => JSON.stringify("${POST_MESSAGE_IDENTIFIER}///${id}///${NAVIGATION_INTERCEPTED_MESSAGE}///nope");
     window.addEventListener("beforeunload", (e) => {
       e.preventDefault();
-      console.warn("unloadingg")
       parent.postMessage(validatedMessage(), "${window.location.href}");
     });
 }


### PR DESCRIPTION
When leaving the main page, the inner iframes would show the "iframe is trying to navigate away" view

This PR fixes it by adding a intermediate, placeholder view (empty, but with the same correct height) as 400ms buffer before the acual view